### PR TITLE
Fixed Lehrmer avg defn

### DIFF
--- a/gen_ave_object.py
+++ b/gen_ave_object.py
@@ -75,7 +75,7 @@ class main_generalzied_object:
         return -1
     def lehmer_for_array(self, x):
         if self.check_array_positivity(x):
-            return np.sum([xx*self.p for xx in x])/ np.sum([xx*(self.p-1) for xx in x])
+            return np.sum([xx**self.p for xx in x])/ np.sum([xx**(self.p-1) for xx in x])
 
         print("Please provide positive data")
         return -1


### PR DESCRIPTION
We had a typo in the defn of Lehrmer avg (we had `*` instead of `**` which resulted in constant output).

Please review and let me know if now it works as expected.